### PR TITLE
Frontend Feed - Add state management 

### DIFF
--- a/client/src/assets/data/filterOptions.js
+++ b/client/src/assets/data/filterOptions.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   location: { label: "Location", options: [] },
   provider: {
     label: "Provider",

--- a/client/src/components/Accordion/FilterAccordion.js
+++ b/client/src/components/Accordion/FilterAccordion.js
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import { Accordion } from "antd-mobile";
-import { ROYAL_BLUE } from "../../constants/colors";
 
 export const FilterAccordion = styled(Accordion)`
   &.am-accordion {

--- a/client/src/components/Button/CustomButton.js
+++ b/client/src/components/Button/CustomButton.js
@@ -1,0 +1,79 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import { Button } from "antd-mobile";
+import { ROYAL_BLUE, SELAGO } from "../../constants/colors";
+
+/* 
+  Props accepted: 
+  inline, primary, large, whitebg, roundborder
+*/
+
+export default styled(Button)`
+  display: ${(props) => (props.inline ? "inline-block" : "initial")};
+  background-color: ${SELAGO};
+  color: #fff;
+  line-height: normal;
+  height: 100%;
+  cursor: pointer;
+
+  
+
+  ${(props) =>
+    props.primary &&
+    css`
+      background-color: ${ROYAL_BLUE};
+      color: #fff;
+
+      &.am-button {
+        &:before {
+          border: 2px solid ${ROYAL_BLUE} !important;
+        }
+      }
+
+      &:hover,
+      &:active,
+      &.am-button-active {
+        background-color: #fff;
+        color: ${ROYAL_BLUE};
+      }
+    `}
+
+  ${(props) =>
+    props.large &&
+    css`
+      padding: 10px 40px;
+      font-size: 15px;
+
+      &.am-button {
+        &:before {
+          border-radius: 40px !important;
+        }
+      }
+    `}
+
+  ${(props) =>
+    props.roundborder &&
+    css`
+      border-radius: 40px;
+    `}
+
+  ${(props) =>
+    props.whitebg &&
+    css`
+      background-color: #fff;
+      color: ${ROYAL_BLUE};
+
+      &.am-button {
+        &:before {
+          border: 2px solid ${ROYAL_BLUE} !important;
+        }
+      }
+
+      &:hover,
+      &:active,
+      &.am-button-active {
+        background-color: ${ROYAL_BLUE};
+        color: #fff;
+      }
+    `}
+`;

--- a/client/src/components/Button/CustomButton.js
+++ b/client/src/components/Button/CustomButton.js
@@ -15,8 +15,7 @@ export default styled(Button)`
   line-height: normal;
   height: 100%;
   cursor: pointer;
-
-  
+  margin-right: 4px;
 
   ${(props) =>
     props.primary &&

--- a/client/src/components/Button/CustomButton.js
+++ b/client/src/components/Button/CustomButton.js
@@ -15,7 +15,7 @@ export default styled(Button)`
   line-height: normal;
   height: 100%;
   cursor: pointer;
-  margin-right: 4px;
+  margin-right: 25px;
   ${(props) =>
     props.primary &&
     css`
@@ -37,11 +37,11 @@ export default styled(Button)`
   ${(props) =>
     props.large &&
     css`
-      padding: 10px 40px;
+      padding: 10px 35px;
       font-size: 15px;
       &.am-button {
         &:before {
-          border-radius: 40px !important;
+          border-radius: 45px !important;
         }
       }
     `}
@@ -49,7 +49,7 @@ export default styled(Button)`
   ${(props) =>
     props.roundborder &&
     css`
-      border-radius: 40px;
+      border-radius: 45px;
     `}
 
   ${(props) =>

--- a/client/src/components/Button/CustomButton.js
+++ b/client/src/components/Button/CustomButton.js
@@ -16,19 +16,16 @@ export default styled(Button)`
   height: 100%;
   cursor: pointer;
   margin-right: 4px;
-
   ${(props) =>
     props.primary &&
     css`
       background-color: ${ROYAL_BLUE};
       color: #fff;
-
       &.am-button {
         &:before {
           border: 2px solid ${ROYAL_BLUE} !important;
         }
       }
-
       &:hover,
       &:active,
       &.am-button-active {
@@ -42,7 +39,6 @@ export default styled(Button)`
     css`
       padding: 10px 40px;
       font-size: 15px;
-
       &.am-button {
         &:before {
           border-radius: 40px !important;
@@ -61,13 +57,11 @@ export default styled(Button)`
     css`
       background-color: #fff;
       color: ${ROYAL_BLUE};
-
       &.am-button {
         &:before {
           border: 2px solid ${ROYAL_BLUE} !important;
         }
       }
-
       &:hover,
       &:active,
       &.am-button-active {

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -5,11 +5,12 @@ import { DARK_GRAY } from "../../constants/colors";
 import filterOptions from "../../assets/data/filterOptions";
 import FilterTag from "../Tag/FilterTag";
 import FilterOptionButton from "../Button/FilterOptionButton";
+import CustomButton from "../../components/Button/CustomButton";
+import CustomList from "../../components/List/CustomList";
 import {
   FilterAccordion,
   FilterAccordionPanel,
 } from "../Accordion/FilterAccordion";
-import CustomButton from "../../components/Button/CustomButton";
 
 const FilterBoxWrapper = styled.div`
   width: 100%;
@@ -65,9 +66,10 @@ export default () => {
             </FilterAccordionPanel>
           ))}
         </FilterAccordion>
-        <List>
+        <CustomList center="true">
           <List.Item>
             <CustomButton
+              // for some reason react wants boolean values for styled components
               inline="true"
               roundborder="true"
               large="true"
@@ -84,7 +86,7 @@ export default () => {
               Apply filters
             </CustomButton>
           </List.Item>
-        </List>
+        </CustomList>
       </Modal>
     </FilterBoxWrapper>
   );

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { Modal, Accordion, SearchBar, List, Button } from "antd-mobile";
 import filterOptions from "../../assets/data/filterOptions";
@@ -22,10 +22,6 @@ export default () => {
   const [activePanel, setActivePanel] = useState("");
   const [selectedFilters, setSelectedFilters] = useState({});
   const filters = Object.values(filterOptions);
-
-  useEffect(() => {
-    console.log(selectedFilters);
-  }, [selectedFilters]);
 
   const openModal = (panelIdx) => (e) => {
     e.preventDefault();
@@ -79,6 +75,10 @@ export default () => {
                 handleClick={handleTag(filter.label, option)}
                 label={option}
                 key={idx}
+                selected={
+                  selectedFilters[filter.label] &&
+                  selectedFilters[filter.label].includes(option)
+                }
               />
             ))}
           </FilterAccordionPanel>

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { Modal, Accordion, SearchBar, List, Button } from "antd-mobile";
 import filterOptions from "../../assets/data/filterOptions";
@@ -23,9 +23,7 @@ export default () => {
   const [selectedFilters, setSelectedFilters] = useState({});
   const [location, setLocation] = useState("");
   const filters = Object.values(filterOptions);
-  useEffect(() => {
-    console.log(location);
-  }, [location]);
+
   const openModal = (panelIdx) => (e) => {
     e.preventDefault();
     setModal(true);

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { Modal, Accordion, Button } from "antd-mobile";
+import { Modal, Accordion, List, Button } from "antd-mobile";
 import { DARK_GRAY } from "../../constants/colors";
 import filterOptions from "../../assets/data/filterOptions";
 import FilterTag from "../Tag/FilterTag";
@@ -9,6 +9,7 @@ import {
   FilterAccordion,
   FilterAccordionPanel,
 } from "../Accordion/FilterAccordion";
+import CustomButton from "../../components/Button/CustomButton";
 
 const FilterBoxWrapper = styled.div`
   width: 100%;
@@ -20,7 +21,7 @@ const FilterTitle = styled.p`
 `;
 
 export default () => {
-  const [modal, setModal] = useState(false);
+  const [modal, setModal] = useState(true);
   const [clickedLabel, setClickedLabel] = useState("");
 
   const openModal = (label) => (e) => {
@@ -44,7 +45,6 @@ export default () => {
           handleClick={openModal(filter.label)}
           key={idx}
           label={filter.label}
-          icon={true}
         />
       ))}
       <Modal
@@ -57,14 +57,34 @@ export default () => {
         }}
       >
         <FilterAccordion className="my-accordion" onChange={onChange}>
-          {Object.values(filterOptions).map((filter) => (
-            <FilterAccordionPanel header={filter.label}>
-              {Object.values(filter.options).map((option) => (
-                <FilterTag label={option} />
+          {Object.values(filterOptions).map((filter, idx) => (
+            <FilterAccordionPanel header={filter.label} key={idx}>
+              {Object.values(filter.options).map((option, idx) => (
+                <FilterTag label={option} key={idx} />
               ))}
             </FilterAccordionPanel>
           ))}
         </FilterAccordion>
+        <List>
+          <List.Item>
+            <CustomButton
+              inline="true"
+              roundborder="true"
+              large="true"
+              whitebg="true"
+            >
+              Quit filters
+            </CustomButton>
+            <CustomButton
+              inline="true"
+              roundborder="true"
+              large="true"
+              primary="true"
+            >
+              Apply filters
+            </CustomButton>
+          </List.Item>
+        </List>
       </Modal>
     </FilterBoxWrapper>
   );

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { Modal, Accordion, SearchBar, List, Button } from "antd-mobile";
 import filterOptions from "../../assets/data/filterOptions";
@@ -21,8 +21,11 @@ export default () => {
   const [modal, setModal] = useState(false);
   const [activePanel, setActivePanel] = useState("");
   const [selectedFilters, setSelectedFilters] = useState({});
+  const [location, setLocation] = useState("");
   const filters = Object.values(filterOptions);
-
+  useEffect(() => {
+    console.log(location);
+  }, [location]);
   const openModal = (panelIdx) => (e) => {
     e.preventDefault();
     setModal(true);
@@ -40,6 +43,12 @@ export default () => {
     setActivePanel(null);
     setSelectedFilters({});
   };
+
+  const handleLocation = (value) => {
+    setLocation(value);
+  };
+
+  const shareMyLocation = () => {};
 
   const handleTag = (label, option) => (e) => {
     e.preventDefault();
@@ -86,7 +95,11 @@ export default () => {
       } else {
         return (
           <FilterAccordionPanel header={filter.label} key={idx}>
-            <LocationSearch />
+            <LocationSearch
+              location={location}
+              handleLocation={handleLocation}
+              shareMyLocation={shareMyLocation}
+            />
           </FilterAccordionPanel>
         );
       }

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -38,6 +38,13 @@ export default () => {
     setActivePanel(null);
   };
 
+  const handleQuit = (e) => {
+    e.preventDefault();
+    setModal(false);
+    setActivePanel(null);
+    setSelectedFilters({});
+  };
+
   const handleTag = (label, option) => (e) => {
     e.preventDefault();
     const options = selectedFilters[label] || [];
@@ -110,6 +117,7 @@ export default () => {
               roundborder="true"
               large="true"
               whitebg="true"
+              onClick={handleQuit}
             >
               Quit filters
             </CustomButton>
@@ -118,6 +126,7 @@ export default () => {
               roundborder="true"
               large="true"
               primary="true"
+              onClick={closeModal}
             >
               Apply filters
             </CustomButton>

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -18,22 +18,22 @@ const FilterBoxWrapper = styled.div`
 `;
 
 export default () => {
-  const [modal, setModal] = useState(true);
-  const [clickedLabel, setClickedLabel] = useState("");
+  const [modal, setModal] = useState(false);
+  const [activePanel, setActivePanel] = useState("");
   const filters = Object.values(filterOptions);
-  const openModal = (label) => (e) => {
+  const openModal = (panelIdx) => (e) => {
     e.preventDefault();
     setModal(true);
-    setClickedLabel(label);
+    setActivePanel(`${panelIdx}`);
   };
   const closeModal = () => {
     setModal(false);
-    setClickedLabel("");
+    setActivePanel(null);
   };
   const renderFilterOptions = (filters) => {
     return filters.map((filter, idx) => (
       <FilterOptionButton
-        handleClick={openModal(filter.label)}
+        handleClick={openModal(idx)}
         key={idx}
         label={filter.label}
       />
@@ -69,7 +69,10 @@ export default () => {
         onClose={closeModal}
         animationType="slide-up"
       >
-        <FilterAccordion className="my-accordion">
+        <FilterAccordion
+          defaultActiveKey={activePanel}
+          className="my-accordion"
+        >
           {renderFilterPanels(filters)}
         </FilterAccordion>
         <CustomList center="true">

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { Modal, Accordion, SearchBar, List, Button } from "antd-mobile";
 import filterOptions from "../../assets/data/filterOptions";
@@ -20,16 +20,38 @@ const FilterBoxWrapper = styled.div`
 export default () => {
   const [modal, setModal] = useState(false);
   const [activePanel, setActivePanel] = useState("");
+  const [selectedFilters, setSelectedFilters] = useState({});
   const filters = Object.values(filterOptions);
+
+  useEffect(() => {
+    console.log(selectedFilters);
+  }, [selectedFilters]);
+
   const openModal = (panelIdx) => (e) => {
     e.preventDefault();
     setModal(true);
     setActivePanel(`${panelIdx}`);
   };
+
   const closeModal = () => {
     setModal(false);
     setActivePanel(null);
   };
+
+  const handleTag = (label, option) => (e) => {
+    e.preventDefault();
+    const options = selectedFilters[label] || [];
+    const optionIdx = options.indexOf(option);
+    let newOptions;
+    if (optionIdx === -1) {
+      newOptions = [...options, option];
+    } else {
+      options.splice(optionIdx, 1);
+      newOptions = options;
+    }
+    setSelectedFilters({ ...selectedFilters, [label]: newOptions });
+  };
+
   const renderFilterOptions = (filters) => {
     return filters.map((filter, idx) => (
       <FilterOptionButton
@@ -39,13 +61,18 @@ export default () => {
       />
     ));
   };
+
   const renderFilterPanels = (filters) => {
     return filters.map((filter, idx) => {
       if (filter.label !== "Location") {
         return (
           <FilterAccordionPanel header={filter.label} key={idx}>
             {Object.values(filter.options).map((option, idx) => (
-              <FilterTag label={option} key={idx} />
+              <FilterTag
+                handleClick={handleTag(filter.label, option)}
+                label={option}
+                key={idx}
+              />
             ))}
           </FilterAccordionPanel>
         );

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import { Modal, Accordion, List, Button } from "antd-mobile";
-import { DARK_GRAY } from "../../constants/colors";
 import filterOptions from "../../assets/data/filterOptions";
 import FilterTag from "../Tag/FilterTag";
+import FilterTitle from "../Typography/Title/FilterTitle";
 import FilterOptionButton from "../Button/FilterOptionButton";
 import CustomButton from "../../components/Button/CustomButton";
 import CustomList from "../../components/List/CustomList";
@@ -15,33 +15,24 @@ import {
 const FilterBoxWrapper = styled.div`
   width: 100%;
 `;
-const FilterTitle = styled.p`
-  color: ${DARK_GRAY};
-  margin: 5px;
-  font-size: 13px;
-`;
 
 export default () => {
   const [modal, setModal] = useState(true);
   const [clickedLabel, setClickedLabel] = useState("");
-
+  const filters = Object.values(filterOptions);
   const openModal = (label) => (e) => {
     e.preventDefault();
     setModal(true);
     setClickedLabel(label);
   };
-
   const closeModal = () => {
     setModal(false);
     setClickedLabel("");
   };
-  const onChange = (key) => {
-    console.log(key);
-  };
   return (
     <FilterBoxWrapper>
       <FilterTitle>Filter by</FilterTitle>
-      {Object.values(filterOptions).map((filter, idx) => (
+      {filters.map((filter, idx) => (
         <FilterOptionButton
           handleClick={openModal(filter.label)}
           key={idx}
@@ -53,12 +44,9 @@ export default () => {
         visible={modal}
         onClose={closeModal}
         animationType="slide-up"
-        afterClose={() => {
-          console.log("afterClose");
-        }}
       >
-        <FilterAccordion className="my-accordion" onChange={onChange}>
-          {Object.values(filterOptions).map((filter, idx) => (
+        <FilterAccordion className="my-accordion">
+          {filters.map((filter, idx) => (
             <FilterAccordionPanel header={filter.label} key={idx}>
               {Object.values(filter.options).map((option, idx) => (
                 <FilterTag label={option} key={idx} />

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { Modal, Accordion, SearchBar, List, Button } from "antd-mobile";
 import filterOptions from "../../assets/data/filterOptions";
@@ -7,6 +7,7 @@ import FilterTitle from "../Typography/Title/FilterTitle";
 import FilterOptionButton from "../Button/FilterOptionButton";
 import CustomButton from "../../components/Button/CustomButton";
 import CustomList from "../../components/List/CustomList";
+import LocationSearch from "../../components/Input/LocationSearch";
 import {
   FilterAccordion,
   FilterAccordionPanel,
@@ -19,7 +20,6 @@ const FilterBoxWrapper = styled.div`
 export default () => {
   const [modal, setModal] = useState(true);
   const [clickedLabel, setClickedLabel] = useState("");
-  const [location, setLocation] = useState("");
   const filters = Object.values(filterOptions);
   const openModal = (label) => (e) => {
     e.preventDefault();
@@ -29,6 +29,15 @@ export default () => {
   const closeModal = () => {
     setModal(false);
     setClickedLabel("");
+  };
+  const renderFilterOptions = (filters) => {
+    return filters.map((filter, idx) => (
+      <FilterOptionButton
+        handleClick={openModal(filter.label)}
+        key={idx}
+        label={filter.label}
+      />
+    ));
   };
   const renderFilterPanels = (filters) => {
     return filters.map((filter, idx) => {
@@ -43,7 +52,7 @@ export default () => {
       } else {
         return (
           <FilterAccordionPanel header={filter.label} key={idx}>
-            <SearchBar placeholder="Search" maxLength={8} />
+            <LocationSearch />
           </FilterAccordionPanel>
         );
       }
@@ -53,13 +62,7 @@ export default () => {
   return (
     <FilterBoxWrapper>
       <FilterTitle>Filter by</FilterTitle>
-      {filters.map((filter, idx) => (
-        <FilterOptionButton
-          handleClick={openModal(filter.label)}
-          key={idx}
-          label={filter.label}
-        />
-      ))}
+      {renderFilterOptions(filters)}
       <Modal
         popup
         visible={modal}

--- a/client/src/components/FilterBox/FilterBox.js
+++ b/client/src/components/FilterBox/FilterBox.js
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import { Modal, Accordion, List, Button } from "antd-mobile";
+import { Modal, Accordion, SearchBar, List, Button } from "antd-mobile";
 import filterOptions from "../../assets/data/filterOptions";
 import FilterTag from "../Tag/FilterTag";
 import FilterTitle from "../Typography/Title/FilterTitle";
@@ -19,6 +19,7 @@ const FilterBoxWrapper = styled.div`
 export default () => {
   const [modal, setModal] = useState(true);
   const [clickedLabel, setClickedLabel] = useState("");
+  const [location, setLocation] = useState("");
   const filters = Object.values(filterOptions);
   const openModal = (label) => (e) => {
     e.preventDefault();
@@ -29,6 +30,26 @@ export default () => {
     setModal(false);
     setClickedLabel("");
   };
+  const renderFilterPanels = (filters) => {
+    return filters.map((filter, idx) => {
+      if (filter.label !== "Location") {
+        return (
+          <FilterAccordionPanel header={filter.label} key={idx}>
+            {Object.values(filter.options).map((option, idx) => (
+              <FilterTag label={option} key={idx} />
+            ))}
+          </FilterAccordionPanel>
+        );
+      } else {
+        return (
+          <FilterAccordionPanel header={filter.label} key={idx}>
+            <SearchBar placeholder="Search" maxLength={8} />
+          </FilterAccordionPanel>
+        );
+      }
+    });
+  };
+
   return (
     <FilterBoxWrapper>
       <FilterTitle>Filter by</FilterTitle>
@@ -46,13 +67,7 @@ export default () => {
         animationType="slide-up"
       >
         <FilterAccordion className="my-accordion">
-          {filters.map((filter, idx) => (
-            <FilterAccordionPanel header={filter.label} key={idx}>
-              {Object.values(filter.options).map((option, idx) => (
-                <FilterTag label={option} key={idx} />
-              ))}
-            </FilterAccordionPanel>
-          ))}
+          {renderFilterPanels(filters)}
         </FilterAccordion>
         <CustomList center="true">
           <List.Item>

--- a/client/src/components/Input/LocationSearch.js
+++ b/client/src/components/Input/LocationSearch.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled, { css } from "styled-components";
 import { SearchBar, Icon, WhiteSpace } from "antd-mobile";
 
@@ -12,12 +12,8 @@ const StyledSearchBar = styled(SearchBar)`
 
 export default () => {
   const [location, setLocation] = useState("");
-  useEffect(() => {
-    // integrate API endpoint here
-    console.log(location);
-  });
   const shareMyLocation = () => {
-    // handle logic for sharing location
+    // integrate API endpoint
   };
   const onChange = (value) => {
     setLocation(value);

--- a/client/src/components/Input/LocationSearch.js
+++ b/client/src/components/Input/LocationSearch.js
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from "react";
+import styled, { css } from "styled-components";
+import { SearchBar, Icon, WhiteSpace } from "antd-mobile";
+
+const StyledSearchBar = styled(SearchBar)`
+  &.am-search {
+    background-color: #fff;
+    border: 1px solid black;
+    border-radius: 40px;
+  }
+`;
+
+export default () => {
+  const [location, setLocation] = useState("");
+  useEffect(() => {
+    // integrate API endpoint here
+    console.log(location);
+  });
+  const shareMyLocation = () => {
+    // handle logic for sharing location
+  };
+  const onChange = (value) => {
+    setLocation(value);
+  };
+  return (
+    <div className="location-search">
+      <WhiteSpace />
+      <StyledSearchBar
+        cancelText="Search"
+        placeholder="Zip code, neighborhood, or city"
+        maxLength={100}
+        value={location}
+        onChange={onChange}
+      />
+      <WhiteSpace />
+      <div onClick={shareMyLocation} href="#">
+        <Icon type="right" />
+        Share My Location
+      </div>
+      <WhiteSpace />
+    </div>
+  );
+};

--- a/client/src/components/Input/LocationSearch.js
+++ b/client/src/components/Input/LocationSearch.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import styled, { css } from "styled-components";
 import { SearchBar, Icon, WhiteSpace } from "antd-mobile";
 
@@ -10,14 +10,7 @@ const StyledSearchBar = styled(SearchBar)`
   }
 `;
 
-export default () => {
-  const [location, setLocation] = useState("");
-  const shareMyLocation = () => {
-    // integrate API endpoint
-  };
-  const onChange = (value) => {
-    setLocation(value);
-  };
+export default ({ location, handleLocation, shareMyLocation }) => {
   return (
     <div className="location-search">
       <WhiteSpace />
@@ -26,10 +19,10 @@ export default () => {
         placeholder="Zip code, neighborhood, or city"
         maxLength={100}
         value={location}
-        onChange={onChange}
+        onChange={handleLocation}
       />
       <WhiteSpace />
-      <div onClick={shareMyLocation} href="#">
+      <div onClick={shareMyLocation}>
         <Icon type="right" />
         Share My Location
       </div>

--- a/client/src/components/List/CustomList.js
+++ b/client/src/components/List/CustomList.js
@@ -1,0 +1,29 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import { List } from "antd-mobile";
+
+/* 
+  Props accepted: 
+  center
+*/
+
+export default styled(List)`
+  &.am-list {
+    .am-list-body {
+      &::before {
+        content: normal !important;
+      }
+      .am-list-line {
+        padding-right: 0;
+        padding-left: 0;
+      }
+    }
+  }
+
+  ${(props) =>
+    props.center &&
+    css`
+      display: flex;
+      justify-content: center;
+    `}
+`;

--- a/client/src/components/Tag/FilterTag.js
+++ b/client/src/components/Tag/FilterTag.js
@@ -22,6 +22,10 @@ const FilterTag = styled(Tag)`
   }
 `;
 
-export default ({ label }) => {
-  return <FilterTag>{label}</FilterTag>;
+export default ({ label, handleClick }) => {
+  return (
+    <FilterTag>
+      <div onClick={handleClick}>{label}</div>
+    </FilterTag>
+  );
 };

--- a/client/src/components/Tag/FilterTag.js
+++ b/client/src/components/Tag/FilterTag.js
@@ -22,9 +22,9 @@ const FilterTag = styled(Tag)`
   }
 `;
 
-export default ({ label, handleClick }) => {
+export default ({ label, selected, handleClick }) => {
   return (
-    <FilterTag>
+    <FilterTag selected={selected}>
       <div onClick={handleClick}>{label}</div>
     </FilterTag>
   );

--- a/client/src/components/Typography/Title/FilterTitle.js
+++ b/client/src/components/Typography/Title/FilterTitle.js
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import { DARK_GRAY } from "../../../constants/colors";
+
+export default styled.p`
+  color: ${DARK_GRAY};
+  margin: 5px;
+  font-size: 13px;
+`;


### PR DESCRIPTION
- Added location search bar
- Added two Quit/Apply buttons at the bottom
- Clicking "Apply filters" saves selected filters
- Clicking "Quit filters" removes all selected filters
- An associated accordion panel gets active and opened when a user clicks on a filter
- Filter tags have selected styling even after closing and reopening the modal

WIP:
- Dynamically render accordions and location results
- Replace the icon on the accordions
- Replace the icon next to "Share my location"
- Change font style of the location search input text



<img width="342" alt="Screen Shot 2020-04-05 at 2 06 58 PM" src="https://user-images.githubusercontent.com/42228386/78510157-1d3b5600-7748-11ea-8a08-cb4f35b569fc.png">
<img width="369" alt="Screen Shot 2020-04-05 at 2 18 25 PM" src="https://user-images.githubusercontent.com/42228386/78510195-6ee3e080-7748-11ea-9e02-73d91c007106.png">
<img width="352" alt="Screen Shot 2020-04-05 at 2 18 32 PM" src="https://user-images.githubusercontent.com/42228386/78510196-71ded100-7748-11ea-82b8-168596e6140b.png">

