### PR TITLE
initial Version

### DIFF
--- a/client/src/pages/CovidScreening/CareFacility.js
+++ b/client/src/pages/CovidScreening/CareFacility.js
@@ -1,0 +1,10 @@
+import React from "react";
+export const CareFacility = () => {
+  return (
+    <div>
+      <p>Contact your facility</p>
+      <p>Self isolate</p>
+      <p>Contact your provider if symptoms worsen</p>
+    </div>
+  );
+};

--- a/client/src/pages/CovidScreening/PlannedCareFacility.js
+++ b/client/src/pages/CovidScreening/PlannedCareFacility.js
@@ -1,0 +1,11 @@
+import React from "react";
+export const PlannedCareFacility = () => {
+  return (
+    <div>
+      <p> Testing Recommended</p>
+      <p> Contact your occupational Health</p>
+      <p> Contact your provider if symptoms worsen </p>
+      <p> Self Isolate </p>
+    </div>
+  );
+};

--- a/client/src/pages/CovidScreening/Under18.js
+++ b/client/src/pages/CovidScreening/Under18.js
@@ -1,0 +1,9 @@
+import React from "react";
+export const Under18 = () => {
+  return (
+    <div>
+      This is intended for only people who are 18 years and above
+      <a href="https://www.cdc.gov/index.htm"> CDC </a>
+    </div>
+  );
+};

--- a/client/src/pages/SymptomsCheck.js
+++ b/client/src/pages/SymptomsCheck.js
@@ -11,6 +11,9 @@ import {
   WizardNav,
 } from "../components/StepWizard";
 import { ResultsPage } from "./ResultsPage.js";
+import { Under18 } from "./CovidScreening/Under18";
+import { PlannedCareFacility } from "./CovidScreening/PlannedCareFacility";
+import { CareFacility } from "./CovidScreening/CareFacility";
 
 const INITIAL_STATE = {};
 
@@ -308,6 +311,19 @@ export const SymptomsCheck = () => {
     setState({ ...state, [key]: value });
   };
   localStorage.setItem("symptomsCheckAnswers", JSON.stringify(state));
+  // console.log(state, " state++++")
+  if (state.age === "under 18") {
+    return <Under18 />;
+  }
+  if (state.careFacility === "planning to") {
+    return <PlannedCareFacility />;
+  }
+  if (
+    state.careFacility === "worked in last 14 days" ||
+    state.careFacility === "currently living"
+  ) {
+    return <CareFacility />;
+  }
 
   return (
     <WizardContainer className="mx-auto">


### PR DESCRIPTION
- when under 18, the process is terminated and directed to a particular screen.
- when symptomatic it gives guidance in line with [this](https://github.com/andreslarezbas/covid19healthbot/blob/master/screening_protocols/covid_19_screening_protocol_cdc_apple.pdf).

NB: - a couple of sections and scenarios are still missing